### PR TITLE
Change the docker image for unlocking cloud build

### DIFF
--- a/pxtarget.json
+++ b/pxtarget.json
@@ -297,5 +297,5 @@
     "errorList": true
   },
   "ignoreDocsErrors": true,
-  "uploadDocs": false
+  "uploadDocs": true
 }


### PR DESCRIPTION
The cloud build of our codal target is not working(see #48). To reproduce the cloud build process locally, I changed our docker image with the one used on the cloud build.