### PR TITLE
Remove useless call to i2c.init()

### DIFF
--- a/libs/lcd/target_lcd.h
+++ b/libs/lcd/target_lcd.h
@@ -7,9 +7,6 @@ class WLCD {
   public:
     codal::STM32I2C i2c;
     codal::rgb_lcd lcd;
-    WLCD() : i2c(*LOOKUP_PIN(SDA), *LOOKUP_PIN(SCL)), lcd(i2c, 16, 2) {
-        i2c.init();
-        lcd.init();
-    }
+    WLCD() : i2c(*LOOKUP_PIN(SDA), *LOOKUP_PIN(SCL)), lcd(i2c, 16, 2) { lcd.init(); }
 };
 } // namespace pxt


### PR DESCRIPTION
close #65