### PR TITLE
fixed wiring mismatch between GND and VCC pins

### DIFF
--- a/libs/hcsr04/pxtparts.json
+++ b/libs/hcsr04/pxtparts.json
@@ -31,7 +31,7 @@
     },
     "pinDefinitions": [
       {
-        "target": "fiveVolt",
+        "target": "ground",
         "style": "croc",
         "orientation": "+Z"
       },
@@ -46,7 +46,7 @@
         "orientation": "+Z"
       },
       {
-        "target": "ground",
+        "target": "fiveVolt",
         "style": "croc",
         "orientation": "+Z"
       }


### PR DESCRIPTION
There was a bug where hcsr-04's VCC pin would be connected to the target's groudn pin, and hcsr-04's GND pin to the target's 5V pin.

Fiexed now